### PR TITLE
docs: add client-side configuration section and refine README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 A lightweight, multi-architecture (`linux/amd64` and `linux/arm64`) Docker image for Snell Server.  
 Supports configuration via environment variables, with secure defaults when not provided: random PSK and random port (>1024).
 
-
 ## Available Images
 
 This project provides Docker images from two sources:
@@ -30,14 +29,14 @@ Both images are identical and you can use either one based on your preference.
 
 ## Environment Variables
 
-| Variable    | Default Value               | Description                                 | Validation Rules |
-| ----------- | --------------------------- | ------------------------------------------- | ---------------- |
-| `PORT`      | Random 1025–65535           | Listening port                              | Must be integer 1025–65535 |
-| `PSK`       | Random 32-char alphanumeric | Pre-shared key                              | Required |
-| `IPv6`      | Not set (optional)          | Enable IPv6                                 | Must be `true` or `false` if provided |
-| `OBFS`      | Not set (optional)          | Obfuscation mode                            | Must be `off` or `http` if provided |
-| `OBFS_HOST` | Not set (optional)          | Obfuscation host                            | Only used when `OBFS=http` |
-| `TFO`       | `true`                      | Enable TCP Fast Open                        | Boolean |
+| Variable    | Default Value               | Description          | Validation Rules                      |
+| ----------- | --------------------------- | -------------------- | ------------------------------------- |
+| `PORT`      | Random 1025–65535           | Listening port       | Must be integer 1025–65535            |
+| `PSK`       | Random 32-char alphanumeric | Pre-shared key       | Required                              |
+| `IPv6`      | Not set (optional)          | Enable IPv6          | Must be `true` or `false` if provided |
+| `OBFS`      | Not set (optional)          | Obfuscation mode     | Must be `off` or `http` if provided   |
+| `OBFS_HOST` | Not set (optional)          | Obfuscation host     | Only used when `OBFS=http`            |
+| `TFO`       | `true`                      | Enable TCP Fast Open | Boolean                               |
 
 ## Configuration Behavior
 
@@ -50,15 +49,11 @@ The server uses conditional configuration writing:
 
 ## Docker Images
 
-### Docker Hub
-
 ```bash
+# Docker Hub
 docker pull 1byte/snell-server
-```
 
-### GitHub Container Registry (GHCR)
-
-```bash
+# GitHub Container Registry
 docker pull ghcr.io/shuidi-l/snell-server
 ```
 
@@ -68,6 +63,8 @@ docker pull ghcr.io/shuidi-l/snell-server
 
 ```bash
 # Build with default Snell version (5.0.0)
+git clone https://github.com/shuidi-l/snell-server-docker.git
+cd snell-server-docker
 docker build -t 1byte/snell-server .
 
 # Build with specific Snell version
@@ -78,6 +75,7 @@ docker build --build-arg SNELL_VERSION=4.1.1 -t 1byte/snell-server:4.1.1 .
 
 ```bash
 # Build with default Snell version (5.0.0)
+cd snell-server-docker # Please make sure to clone it first before proceeding
 docker buildx build \
   --platform linux/amd64,linux/arm64 \
   -t 1byte/snell-server:latest .
@@ -91,7 +89,7 @@ docker buildx build \
 
 ## Run Examples
 
-### Default config (random port & PSK)
+### Default config (random port & PSK, for testing only)
 
 ```bash
 # Using Docker Hub
@@ -105,79 +103,25 @@ docker run --rm ghcr.io/shuidi-l/snell-server
 
 ```bash
 # Using Docker Hub
-docker run --rm -p 8234:8234 \
+docker run -it -p 8234:8234 \
   -e PORT=8234 \
   -e PSK=mysecurepsk \
   1byte/snell-server
 
 # Using GitHub Container Registry
-docker run --rm -p 8234:8234 \
+docker run -it -p 8234:8234 \
   -e PORT=8234 \
   -e PSK=mysecurepsk \
-  ghcr.io/shuidi-l/snell-server
-```
-
-### Enable IPv6
-
-```bash
-# Using Docker Hub
-docker run --rm -p 8234:8234 \
-  -e PORT=8234 \
-  -e PSK=mysecurepsk \
-  -e IPv6=true \
-  1byte/snell-server
-
-# Using GitHub Container Registry
-docker run --rm -p 8234:8234 \
-  -e PORT=8234 \
-  -e PSK=mysecurepsk \
-  -e IPv6=true \
-  ghcr.io/shuidi-l/snell-server
-```
-
-### Enable obfuscation with custom host
-
-```bash
-# Using Docker Hub
-docker run --rm -p 9000:9000 \
-  -e PORT=9000 \
-  -e PSK=mysecurepsk \
-  -e OBFS=http \
-  -e OBFS_HOST=my.domain.com \
-  1byte/snell-server
-
-# Using GitHub Container Registry
-docker run --rm -p 9000:9000 \
-  -e PORT=9000 \
-  -e PSK=mysecurepsk \
-  -e OBFS=http \
-  -e OBFS_HOST=my.domain.com \
-  ghcr.io/shuidi-l/snell-server
-```
-
-### Disable obfuscation
-
-```bash
-# Using Docker Hub
-docker run --rm -p 9000:9000 \
-  -e PORT=9000 \
-  -e PSK=mysecurepsk \
-  -e OBFS=off \
-  1byte/snell-server
-
-# Using GitHub Container Registry
-docker run --rm -p 9000:9000 \
-  -e PORT=9000 \
-  -e PSK=mysecurepsk \
-  -e OBFS=off \
   ghcr.io/shuidi-l/snell-server
 ```
 
 ### Complete configuration example
 
+Please refer to the `Environment Variables` section and adjust them as needed.  For example, you can disable obfuscation by setting: `OBFS=off`
+
 ```bash
 # Using Docker Hub
-docker run --rm -p 8234:8234 \
+docker run -itd -p 8234:8234 \
   -e PORT=8234 \
   -e PSK=mysecurepsk \
   -e IPv6=true \
@@ -187,7 +131,7 @@ docker run --rm -p 8234:8234 \
   1byte/snell-server
 
 # Using GitHub Container Registry
-docker run --rm -p 8234:8234 \
+docker run -itd -p 8234:8234 \
   -e PORT=8234 \
   -e PSK=mysecurepsk \
   -e IPv6=true \
@@ -204,7 +148,9 @@ docker run --rm -p 8234:8234 \
 1. Ensure `docker-compose.yml` is in your working directory
 2. Provide environment variables via a `.env` file (recommended) or your shell
 
-Example `.env` (place next to `docker-compose.yml`):
+#### Example `.env` and docker-compose.yml(place next to `docker-compose.yml`):
+
+##### `.env`
 
 ```env
 PORT=8234
@@ -215,13 +161,29 @@ PSK=mysecurepsk
 # OBFS_HOST=gateway.icloud.com
 ```
 
-Start the service:
+##### `docker-compose.yml`
 
-```bash
-docker compose up -d
+```yaml
+services:
+  snell-server:
+    container_name: snell-server
+    restart: always
+    image: 1byte/snell-server:latest
+    ports:
+      - "${PORT:-8234}:${PORT:-8234}"   # Default to 8234 if PORT is not set
+    environment:
+      PORT: "${PORT}"
+      PSK: "${PSK}"
+      # IPv6: "${IPv6}"
+      # TFO: "${TFO}"
+      # OBFS: "${OBFS}"        # Set to "false" to disable; `http` enables it
+      # OBFS_HOST: "${OBFS_HOST}"
+    # volumes:
+    #   - ./snell-server.conf:/app/snell-server.conf
 ```
 
-### Use a custom snell-server.conf
+
+##### Use a custom snell-server.conf
 
 If you already have a `snell-server.conf`, mount it and the script will skip auto-generation:
 
@@ -235,6 +197,45 @@ services:
 
 With this volume mount, the container will use your provided config file and ignore environment variables for generation.
 
+##### Start the service:
+
+```bash
+docker compose up -d
+```
+
+### Surge Client-Side Settings(iOS & macOS)
+
+#### Prerequisites
+
+- Apply for a  public IP address from your ISP
+- Port mapping
+- Optional: A domain and a DNS provider(e.g, Cloudflare, AliCloud).  If you are going to use a DNS provider and your IP is dynamic, I recommend ddns-go for automatic DNS updates. It's a simple and easy-to-use DDNS tool. See [^3] for more details.
+
+Add the following to your Surge configuration file (e.g, Surge.conf), and replace placeholders like `YOUR_FQDN`, `YOUR_PUBLIC_IP`,  `YOUR_DOMAIN`, `${PORT}`,  `${PSK}`,  `MyHome` and `IP-CIDR,192.168.188.0/24` with your actual values.
+
+To learn more about `Surge Policy Groups`, see Surge Policy Group documentation[^1] and Surge Manual[^2]. For more information on Snell, refer to Snell knowledge[^4].
+
+```vim
+[Proxy]
+home = snell, YOUR_FQDN or YOUR_PUBLIC_IP, ${PORT}, psk=${PSK}, version=5, reuse=true
+# If obfuscation is enabled:
+# home = snell, YOUR_PUBLIC_IP or YOUR_FQDN, YOUR_PORT, psk=YOUR_PSK, version=5, obfs=http, obfs-host=YOUR_OBFS_HOST, reuse=true, tfo=true
+...
+[Proxy Group]
+# Define a policy group named `🏠Home` of type `subnet`.  
+# Behavior: If the current Wi-Fi SSID is `MyHome`, connect directly;  
+# otherwise, switch to the `🏠Home` policy group.
+# Please refer to [^1] for more details.
+🏠Home = subnet, default = home, SSID:MyHome = DIRECT
+...
+[Rule]
+IP-CIDR,192.168.188.0/24,🏠Home,no-resolve
+# Modify the following line as needed when using DNS(e.g, Cloudflare or another provider.)
+OR,((DOMAIN,plex.YOUR_DOMAIN), (DOMAIN,vw.YOUR_DOMAIN), (DOMAIN,gitea.YOUR_DOMAIN), (DOMAIN,myns.YOUR_DOMAIN)),🏠Home
+...
+```
+
+
 ## Error Handling
 
 The server validates all input values before starting:
@@ -245,9 +246,14 @@ The server validates all input values before starting:
 
 If any validation fails, the server will display an error message and exit with code 1.
 
+
+[^1]: https://manual.nssurge.com/policy-group/subnet.html
+[^2]: https://manual.nssurge.com/book/understanding-surge/cn/
+[^3]: https://github.com/jeessy2/ddns-go
+[^4]: https://kb.nssurge.com/surge-knowledge-base/release-notes/snell
+
 ## License
 
 [LICENSE](LICENSE)
 
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fshuidi-l%2Fsnell-server.svg?type=large&issueType=license)](https://app.fossa.com/projects/git%2Bgithub.com%2Fshuidi-l%2Fsnell-server?ref=badge_large&issueType=license)
-

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -5,8 +5,12 @@
 # Snell Server Docker 镜像
  [![Build](https://github.com/shuidi-l/snell-server-docker/actions/workflows/build-push.yml/badge.svg)](https://github.com/shuidi-l/snell-server-docker/actions/workflows/build-push.yml) [![Release](https://img.shields.io/github/release/shuidi-l/snell-server-docker.svg?style=flat-square&logo=github&logoColor=fff&color=005AA4)](https://github.com/shuidi-l/snell-server-docker/releases) [![Image Size](https://img.shields.io/docker/image-size/1byte/snell-server?style=&logo=docker)](https://hub.docker.com/r/1byte/snell-server/) [![Docker Pulls](https://img.shields.io/docker/pulls/1byte/snell-server.svg?style=&logo=docker)](https://hub.docker.com/r/1byte/snell-server) [![Docker Stars](https://img.shields.io/docker/stars/1byte/snell-server.svg?style=flat-square&logo=docker)](https://hub.docker.com/r/1byte/snell-server/) [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fshuidi-l%2Fsnell-server.svg?type=small)](https://app.fossa.com/projects/git%2Bgithub.com%2Fshuidi-l%2Fsnell-server?ref=badge_small) [![Repository License](https://img.shields.io/badge/license-MIT-brightgreen.svg)](https://opensource.org/license/mit)
 
-一个轻量级的、支持多架构（`linux/amd64` 和 `linux/arm64`）的 Snell Server Docker 镜像。  
-支持通过环境变量进行配置，当未提供时使用安全默认值：随机 PSK 和随机端口（>1024）。
+一个轻量级的、支持多架构（`linux/amd64` 和 `linux/arm64`）的 Snell Server Docker 镜像。
+
+## 为什么需要它
+
+本项目提供开箱即用、默认安全的最小镜像，可自动生成有效配置（或复用现有配置），并在多架构环境下统一体验，让你从"可用"到"上线"只需几秒。
+
 
 ## 可用镜像
 
@@ -27,16 +31,30 @@
 - **条件配置**：仅在提供值时写入可选字段
 - **输入验证**：在启动前验证 IPv6 和 OBFS 值
 
+## 贡献
+
+欢迎任何形式的贡献！如果你有改进建议、问题报告或新特性想法：
+
+- 先开一个 Issue 讨论你的提议
+- 提交聚焦的 PR
+- 可从 "good first issue" 与 "help wanted" 标签的问题着手
+
+提交代码的同时，也请同步更新相关文档与示例。
+
+## 支持与响应
+
+如有问题，欢迎开 Issue。我会尽量保持响应，尤其欢迎首次贡献者。即使只是反馈和建议，也非常有价值。
+
 ## 环境变量
 
-| 变量        | 默认值                     | 描述                                     | 验证规则 |
-| ----------- | --------------------------- | ---------------------------------------- | -------- |
-| `PORT`      | 随机 1025–65535            | 监听端口                                 | 必须是 1025–65535 之间的整数 |
-| `PSK`       | 随机 32 字符字母数字        | 预共享密钥                               | 必需 |
-| `IPv6`      | 未设置（可选）              | 启用 IPv6                                | 如果提供，必须是 `true` 或 `false` |
-| `OBFS`      | 未设置（可选）              | 混淆模式                                 | 如果提供，必须是 `off` 或 `http` |
-| `OBFS_HOST` | 未设置（可选）              | 混淆主机                                 | 仅在 `OBFS=http` 时使用 |
-| `TFO`       | `true`                      | 启用 TCP Fast Open                       | 布尔值 |
+| 变量        | 默认值                     | 描述          | 验证规则                      |
+| ----------- | --------------------------- | ------------- | ----------------------------- |
+| `PORT`      | 随机 1025–65535            | 监听端口      | 必须是 1025–65535 之间的整数  |
+| `PSK`       | 随机 32 字符字母数字        | 预共享密钥    | 必需                          |
+| `IPv6`      | 未设置（可选）              | 启用 IPv6     | 如果提供，必须是 `true` 或 `false` |
+| `OBFS`      | 未设置（可选）              | 混淆模式      | 如果提供，必须是 `off` 或 `http` |
+| `OBFS_HOST` | 未设置（可选）              | 混淆主机      | 仅在 `OBFS=http` 时使用       |
+| `TFO`       | `true`                      | 启用 TCP Fast Open | 布尔值                    |
 
 ## 配置行为
 
@@ -49,15 +67,11 @@
 
 ## Docker 镜像
 
-### Docker Hub
-
 ```bash
+# Docker Hub
 docker pull 1byte/snell-server
-```
 
-### GitHub Container Registry (GHCR)
-
-```bash
+# GitHub Container Registry
 docker pull ghcr.io/shuidi-l/snell-server
 ```
 
@@ -67,6 +81,8 @@ docker pull ghcr.io/shuidi-l/snell-server
 
 ```bash
 # 使用默认 Snell 版本构建（5.0.0）
+git clone https://github.com/shuidi-l/snell-server-docker.git
+cd snell-server-docker
 docker build -t 1byte/snell-server .
 
 # 使用指定 Snell 版本构建
@@ -77,6 +93,7 @@ docker build --build-arg SNELL_VERSION=4.1.1 -t 1byte/snell-server:4.1.1 .
 
 ```bash
 # 使用默认 Snell 版本构建（5.0.0）
+cd snell-server-docker # 请确保先克隆仓库
 docker buildx build \
   --platform linux/amd64,linux/arm64 \
   -t 1byte/snell-server:latest .
@@ -90,7 +107,7 @@ docker buildx build \
 
 ## 运行示例
 
-### 默认配置（随机端口和 PSK）
+### 默认配置（随机端口和 PSK，仅用于测试）
 
 ```bash
 # 使用 Docker Hub
@@ -104,79 +121,25 @@ docker run --rm ghcr.io/shuidi-l/snell-server
 
 ```bash
 # 使用 Docker Hub
-docker run --rm -p 8234:8234 \
+docker run -itd -p 8234:8234 \
   -e PORT=8234 \
   -e PSK=mysecurepsk \
   1byte/snell-server
 
 # 使用 GitHub Container Registry
-docker run --rm -p 8234:8234 \
+docker run -itd -p 8234:8234 \
   -e PORT=8234 \
   -e PSK=mysecurepsk \
-  ghcr.io/shuidi-l/snell-server
-```
-
-### 启用 IPv6
-
-```bash
-# 使用 Docker Hub
-docker run --rm -p 8234:8234 \
-  -e PORT=8234 \
-  -e PSK=mysecurepsk \
-  -e IPv6=true \
-  1byte/snell-server
-
-# 使用 GitHub Container Registry
-docker run --rm -p 8234:8234 \
-  -e PORT=8234 \
-  -e PSK=mysecurepsk \
-  -e IPv6=true \
-  ghcr.io/shuidi-l/snell-server
-```
-
-### 启用混淆并自定义主机
-
-```bash
-# 使用 Docker Hub
-docker run --rm -p 9000:9000 \
-  -e PORT=9000 \
-  -e PSK=mysecurepsk \
-  -e OBFS=http \
-  -e OBFS_HOST=my.domain.com \
-  1byte/snell-server
-
-# 使用 GitHub Container Registry
-docker run --rm -p 9000:9000 \
-  -e PORT=9000 \
-  -e PSK=mysecurepsk \
-  -e OBFS=http \
-  -e OBFS_HOST=my.domain.com \
-  ghcr.io/shuidi-l/snell-server
-```
-
-### 禁用混淆
-
-```bash
-# 使用 Docker Hub
-docker run --rm -p 9000:9000 \
-  -e PORT=9000 \
-  -e PSK=mysecurepsk \
-  -e OBFS=off \
-  1byte/snell-server
-
-# 使用 GitHub Container Registry
-docker run --rm -p 9000:9000 \
-  -e PORT=9000 \
-  -e PSK=mysecurepsk \
-  -e OBFS=off \
   ghcr.io/shuidi-l/snell-server
 ```
 
 ### 完整配置示例
 
+请参考 `环境变量` 部分并根据需要调整。例如，可以通过设置 `OBFS=off` 来禁用混淆。
+
 ```bash
 # 使用 Docker Hub
-docker run --rm -p 8234:8234 \
+docker run -itd -p 8234:8234 \
   -e PORT=8234 \
   -e PSK=mysecurepsk \
   -e IPv6=true \
@@ -186,7 +149,7 @@ docker run --rm -p 8234:8234 \
   1byte/snell-server
 
 # 使用 GitHub Container Registry
-docker run --rm -p 8234:8234 \
+docker run -itd -p 8234:8234 \
   -e PORT=8234 \
   -e PSK=mysecurepsk \
   -e IPv6=true \
@@ -203,7 +166,9 @@ docker run --rm -p 8234:8234 \
 1. 确保 `docker-compose.yml` 位于当前工作目录
 2. 通过 `.env` 文件（推荐）或 Shell 提供环境变量
 
-示例 `.env`（与 `docker-compose.yml` 同目录）：
+#### 示例 `.env` 和 docker-compose.yml（与 `docker-compose.yml` 同目录）：
+
+##### `.env`
 
 ```env
 PORT=8234
@@ -214,13 +179,29 @@ PSK=mysecurepsk
 # OBFS_HOST=gateway.icloud.com
 ```
 
-启动服务：
+##### `docker-compose.yml`
 
-```bash
-docker compose up -d
+```yaml
+services:
+  snell-server:
+    container_name: snell-server
+    restart: always
+    image: 1byte/snell-server:latest
+    ports:
+      - "${PORT:-8234}:${PORT:-8234}"   # 如果未设置 PORT，默认为 8234
+    environment:
+      PORT: "${PORT}"
+      PSK: "${PSK}"
+      # IPv6: "${IPv6}"
+      # TFO: "${TFO}"
+      # OBFS: "${OBFS}"        # 设置为 "false" 禁用；`http` 启用
+      # OBFS_HOST: "${OBFS_HOST}"
+    # volumes:
+    #   - ./snell-server.conf:/app/snell-server.conf
 ```
 
-### 使用自定义 snell-server.conf
+
+##### 使用自定义 snell-server.conf
 
 如果你已经有 `snell-server.conf`，可通过挂载使用，脚本会跳过自动生成：
 
@@ -234,6 +215,44 @@ services:
 
 启用该挂载后，容器将使用你提供的配置文件，环境变量将不再用于生成配置。
 
+##### 启动服务：
+
+```bash
+docker compose up -d
+```
+
+### Surge 客户端设置（iOS & macOS）
+
+#### 前置要求
+
+- 向 ISP 申请公网 IP 地址
+- 端口映射
+- 可选：域名和 DNS 提供商（如 Cloudflare、阿里云）。如果你的 IP 是动态的，建议使用 ddns-go 进行自动 DNS 更新。这是一个简单易用的 DDNS 工具。详见 [^3]。
+
+把下面内容添加到Surge配置文件中，并将`YOUR_FQDN`、`YOUR_PUBLIC_IP`、`YOUR_DOMAIN`、`${PORT}`、`${PSK}`、`MyHome` 和 `IP-CIDR,192.168.188.0/24` 替换为你的实际值。
+
+要了解更多关于 `Surge 策略组` 的信息，请参阅 Surge 策略组文档[^1] 和 Surge 手册[^2]。有关 Snell 的更多信息，请参考 Snell 知识库[^4]。
+
+```vim
+[Proxy]
+home = snell, YOUR_FQDN or YOUR_PUBLIC_IP, ${PORT}, psk=${PSK}, version=5, reuse=true
+# 如果启用了混淆 
+# home = snell, YOUR_PUBLIC_IP or YOUR_FQDN, YOUR_PORT, psk=YOUR_PSK, version=5, obfs=http, obfs-host=YOUR_OBFS_HOST, reuse=true, tfo=true
+...
+[Proxy Group]
+# 定义一个名为 `🏠Home` 的 `subnet` 类型策略组。
+# 如果当前 Wi-Fi SSID 是 `MyHome`，则直连；
+# 否则切换到 `🏠Home` 策略组。
+# 更多详情请参考 [^1]。
+🏠Home = subnet, default = home, SSID:MyHome = DIRECT
+...
+[Rule]
+IP-CIDR,192.168.188.0/24,🏠Home,no-resolve
+# 使用 DNS（如 Cloudflare 或其他提供商）时，根据需要修改以下行。
+OR,((DOMAIN,plex.YOUR_DOMAIN), (DOMAIN,vw.YOUR_DOMAIN), (DOMAIN,gitea.YOUR_DOMAIN), (DOMAIN,myns.YOUR_DOMAIN)),🏠Home
+...
+```
+
 ## 错误处理
 
 服务器在启动前验证所有输入值：
@@ -243,6 +262,12 @@ services:
 - **无效的 OBFS**：如果提供，必须是 `off` 或 `http`
 
 如果任何验证失败，服务器将显示错误消息并以代码 1 退出。
+
+
+[^1]: https://manual.nssurge.com/policy-group/subnet.html
+[^2]: https://manual.nssurge.com/book/understanding-surge/cn/
+[^3]: https://github.com/jeessy2/ddns-go
+[^4]: https://kb.nssurge.com/surge-knowledge-base/release-notes/snell
 
 ## 许可证
 


### PR DESCRIPTION

- Added Client-Side Configuration section for Surge
- Integrated ddns-go recommendation for dynamic IPs in prerequisites
- Refined Surge Policy Group sentence with direct links to documentation
- Included reference section for footnote citations